### PR TITLE
updating Sunshine GET Events endpoint

### DIFF
--- a/assets/iframe.html
+++ b/assets/iframe.html
@@ -232,7 +232,7 @@
         var settings = {
               "async": true,
               "crossDomain": true,
-              "url": "/api/cdp/events?user_id=" + user_id,
+              "url": "/api/sunshine/events?identifier=support:user_id:" + user_id,
               "method": "GET",
               "headers": {
                 "content-type": "application/json"


### PR DESCRIPTION
using the new Sunshine GET Events endpoint with a query instead of the deprecated "cdp" one